### PR TITLE
fix: persist daily filtration volume across restarts

### DIFF
--- a/custom_components/poolcop/coordinator.py
+++ b/custom_components/poolcop/coordinator.py
@@ -607,9 +607,7 @@ class PoolCopDataUpdateCoordinator(DataUpdateCoordinator[PoolCopData]):
                 if stored_data["daily_volume_date"] == today:
                     self._daily_volume = float(stored_data["daily_volume"])
                     self._daily_volume_date = today
-                    LOGGER.debug(
-                        "Restored daily volume: %.3f m³", self._daily_volume
-                    )
+                    LOGGER.debug("Restored daily volume: %.3f m³", self._daily_volume)
 
     async def async_config_entry_first_refresh(self) -> None:
         """First refresh handling."""

--- a/custom_components/poolcop/coordinator.py
+++ b/custom_components/poolcop/coordinator.py
@@ -580,6 +580,8 @@ class PoolCopDataUpdateCoordinator(DataUpdateCoordinator[PoolCopData]):
         data = {
             "cycle_durations": self._cycle_durations,
             "flow_rates": self.flow_rates,
+            "daily_volume": self._daily_volume,
+            "daily_volume_date": self._daily_volume_date,
         }
         await self._store.async_save(data)
         LOGGER.debug("Saved learned data to persistent storage")
@@ -599,6 +601,15 @@ class PoolCopDataUpdateCoordinator(DataUpdateCoordinator[PoolCopData]):
                 for k, v in stored_data["flow_rates"].items():
                     self.flow_rates[int(k)] = v
                 LOGGER.debug("Loaded saved flow rates: %s", self.flow_rates)
+
+            if "daily_volume" in stored_data and "daily_volume_date" in stored_data:
+                today = datetime.now().strftime("%Y-%m-%d")
+                if stored_data["daily_volume_date"] == today:
+                    self._daily_volume = float(stored_data["daily_volume"])
+                    self._daily_volume_date = today
+                    LOGGER.debug(
+                        "Restored daily volume: %.3f m³", self._daily_volume
+                    )
 
     async def async_config_entry_first_refresh(self) -> None:
         """First refresh handling."""

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -393,9 +393,7 @@ async def test_daily_volume_date_exception(
         coordinator.data = await coordinator._async_update_data()
 
         # Mock datetime.now to raise, triggering the except branch (lines 183-184)
-        with patch(
-            "custom_components.poolcop.coordinator.datetime"
-        ) as mock_dt:
+        with patch("custom_components.poolcop.coordinator.datetime") as mock_dt:
             mock_dt.now.side_effect = RuntimeError("broken clock")
             # Should not crash — today=None means no date reset
             coordinator._update_daily_volume()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,6 +1,7 @@
 """Test PoolCop coordinator functionality."""
 
 import time
+from datetime import datetime
 from unittest.mock import patch
 
 import pytest
@@ -310,25 +311,62 @@ async def test_save_load_learned_data(
 
         # Mock the Store methods directly
         coordinator._store.async_save = AsyncMock()
-        # JSON serializes int keys as strings; simulate that
-        coordinator._store.async_load = AsyncMock(
-            return_value={
-                "cycle_durations": {"1": 9999},
-                "flow_rates": {"2": 18.0},
-            }
-        )
 
-        # Verify save calls the store
+        # Verify save includes daily_volume fields
+        coordinator._daily_volume = 1.234
+        coordinator._daily_volume_date = "2026-03-15"
         await coordinator.async_save_learned_data()
         coordinator._store.async_save.assert_called_once()
         saved = coordinator._store.async_save.call_args[0][0]
         assert "cycle_durations" in saved
         assert "flow_rates" in saved
+        assert saved["daily_volume"] == 1.234
+        assert saved["daily_volume_date"] == "2026-03-15"
 
-        # Verify load converts string keys back to int
+        # JSON serializes int keys as strings; simulate that
+        today = datetime.now().strftime("%Y-%m-%d")
+        coordinator._store.async_load = AsyncMock(
+            return_value={
+                "cycle_durations": {"1": 9999},
+                "flow_rates": {"2": 18.0},
+                "daily_volume": 2.567,
+                "daily_volume_date": today,
+            }
+        )
+
+        # Verify load converts string keys back to int and restores daily volume
         await coordinator.async_load_learned_data()
         assert coordinator._cycle_durations[1] == 9999
         assert coordinator.flow_rates[2] == 18.0
+        assert coordinator._daily_volume == 2.567
+
+
+async def test_load_stale_daily_volume_discarded(
+    hass: HomeAssistant, mock_config_entry, mock_poolcop
+):
+    """Daily volume from a previous day is not restored."""
+    from unittest.mock import AsyncMock
+
+    mock_config_entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.poolcop.coordinator.PoolCopilot",
+        return_value=mock_poolcop,
+    ):
+        coordinator = PoolCopDataUpdateCoordinator(
+            hass=hass, api_key="test-api-key", config_entry=mock_config_entry
+        )
+        coordinator._store.async_load = AsyncMock(
+            return_value={
+                "cycle_durations": {},
+                "flow_rates": {},
+                "daily_volume": 5.0,
+                "daily_volume_date": "2020-01-01",
+            }
+        )
+        await coordinator.async_load_learned_data()
+        # Stale date → volume should NOT be restored
+        assert coordinator._daily_volume == 0.0
 
 
 async def test_status_value_non_dict_intermediate(mock_poolcop_data):

--- a/tests/test_coordinator_cycles.py
+++ b/tests/test_coordinator_cycles.py
@@ -128,5 +128,3 @@ async def test_cycle_no_transition_same_mode(coordinator):
 
     coordinator._update_cycle_tracking(_make_status(3))
     assert len(coordinator._cycle_transitions) == 0
-
-

--- a/tests/test_coordinator_planned.py
+++ b/tests/test_coordinator_planned.py
@@ -1,6 +1,6 @@
 """Test planned remaining volume/turnovers coordinator logic."""
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime
 from unittest.mock import patch
 
 import pytest
@@ -69,7 +69,14 @@ def _make_status(
                     "stop": cycle2_stop,
                 },
             },
-            "conf": {"orp": 0, "pH": 0, "waterlevel": 0, "ioniser": 0, "autochlor": 0, "air": 0},
+            "conf": {
+                "orp": 0,
+                "pH": 0,
+                "waterlevel": 0,
+                "ioniser": 0,
+                "autochlor": 0,
+                "air": 0,
+            },
             "alerts": [],
         },
         "Pool": {
@@ -92,7 +99,7 @@ async def coordinator(hass: HomeAssistant, mock_config_entry, mock_poolcop):
     return coord
 
 
-def _freeze_time(hour, minute=0, tz=timezone.utc):
+def _freeze_time(hour, minute=0, tz=UTC):
     """Return a fixed datetime for mocking."""
     return datetime(2026, 3, 14, hour, minute, 0, tzinfo=tz)
 
@@ -101,9 +108,14 @@ async def test_auto_mode_both_cycles_future(coordinator):
     """Both cycles ahead of now -> full volume from both (op_mode=3 Auto)."""
     status = _make_status(
         op_mode=3,
-        cycle1_enabled=1, cycle1_start="14:00:00", cycle1_stop="18:00:00",
-        cycle2_enabled=1, cycle2_start="20:00:00", cycle2_stop="22:00:00",
-        speed_cycle1=2, speed_cycle2=1,
+        cycle1_enabled=1,
+        cycle1_start="14:00:00",
+        cycle1_stop="18:00:00",
+        cycle2_enabled=1,
+        cycle2_start="20:00:00",
+        cycle2_stop="22:00:00",
+        speed_cycle1=2,
+        speed_cycle2=1,
     )
     coordinator.data = PoolCopData(status=status)
 
@@ -123,7 +135,9 @@ async def test_timer_mode_cycle1_in_progress(coordinator):
     """Mid-cycle1 -> partial remaining volume (op_mode=4 Timer)."""
     status = _make_status(
         op_mode=4,
-        cycle1_enabled=1, cycle1_start="08:00:00", cycle1_stop="12:00:00",
+        cycle1_enabled=1,
+        cycle1_start="08:00:00",
+        cycle1_stop="12:00:00",
         speed_cycle1=2,
     )
     coordinator.data = PoolCopData(status=status)
@@ -144,7 +158,9 @@ async def test_timer_mode_cycle1_done(coordinator):
     """Past stop -> 0 for cycle1 (op_mode=4 Timer)."""
     status = _make_status(
         op_mode=4,
-        cycle1_enabled=1, cycle1_start="06:00:00", cycle1_stop="08:00:00",
+        cycle1_enabled=1,
+        cycle1_start="06:00:00",
+        cycle1_stop="08:00:00",
         speed_cycle1=2,
     )
     coordinator.data = PoolCopData(status=status)
@@ -164,7 +180,9 @@ async def test_timer_mode_cycle2_disabled(coordinator):
     """Only cycle1 contributes when cycle2 is disabled (op_mode=4 Timer)."""
     status = _make_status(
         op_mode=4,
-        cycle1_enabled=1, cycle1_start="14:00:00", cycle1_stop="18:00:00",
+        cycle1_enabled=1,
+        cycle1_start="14:00:00",
+        cycle1_stop="18:00:00",
         cycle2_enabled=0,
         speed_cycle1=2,
     )
@@ -186,7 +204,9 @@ async def test_eco_mode_uses_timers(coordinator):
     """ECO+ filter mode (timer=2) with Auto running status uses timer logic."""
     status = _make_status(
         op_mode=3,
-        cycle1_enabled=1, cycle1_start="14:00:00", cycle1_stop="16:00:00",
+        cycle1_enabled=1,
+        cycle1_start="14:00:00",
+        cycle1_stop="16:00:00",
         speed_cycle1=2,
     )
     coordinator.data = PoolCopData(status=status)
@@ -225,7 +245,7 @@ async def test_manual_mode_returns_zero(coordinator):
 
 
 async def test_continuous_mode_remaining_hours(coordinator):
-    """filter_timer=4 (CONTINUOUS 23h/day) -> remaining hours × flow rate."""
+    """filter_timer=4 (CONTINUOUS 23h/day) -> remaining hours x flow rate."""
     status = _make_status(op_mode=9, filter_timer=4, pump_speed=2)
     coordinator.data = PoolCopData(status=status)
 
@@ -242,7 +262,7 @@ async def test_continuous_mode_remaining_hours(coordinator):
 
 
 async def test_always_on_mode(coordinator):
-    """filter_timer=8 (24/24 Always On) -> remaining hours × flow rate."""
+    """filter_timer=8 (24/24 Always On) -> remaining hours x flow rate."""
     status = _make_status(op_mode=9, filter_timer=8, pump_speed=2)
     coordinator.data = PoolCopData(status=status)
 
@@ -261,8 +281,11 @@ async def test_always_on_mode(coordinator):
 async def test_always_on_overrides_op_mode(coordinator):
     """filter_timer=8 (24/24) takes priority even if op_mode is Auto (3)."""
     status = _make_status(
-        op_mode=3, filter_timer=8,
-        cycle1_enabled=1, cycle1_start="14:00:00", cycle1_stop="16:00:00",
+        op_mode=3,
+        filter_timer=8,
+        cycle1_enabled=1,
+        cycle1_start="14:00:00",
+        cycle1_stop="16:00:00",
         pump_speed=2,
     )
     coordinator.data = PoolCopData(status=status)
@@ -280,7 +303,7 @@ async def test_always_on_overrides_op_mode(coordinator):
 
 
 async def test_forced_mode_uses_remaining_hours(coordinator):
-    """op_mode=2 (Forced) -> forced.remaining_hours × flow rate."""
+    """op_mode=2 (Forced) -> forced.remaining_hours x flow rate."""
     status = _make_status(op_mode=2, filter_timer=1, pump_speed=2, forced_remaining=10)
     coordinator.data = PoolCopData(status=status)
 
@@ -301,7 +324,9 @@ async def test_no_flow_rates_returns_zero(coordinator):
     coordinator.flow_rates = {}  # Clear all flow rates
 
     status = _make_status(
-        op_mode=4, cycle1_start="14:00:00", cycle1_stop="18:00:00",
+        op_mode=4,
+        cycle1_start="14:00:00",
+        cycle1_stop="18:00:00",
     )
     coordinator.data = PoolCopData(status=status)
 
@@ -320,8 +345,11 @@ async def test_turnovers_normal(coordinator):
     """volume / pool_volume gives correct turnovers."""
     status = _make_status(
         op_mode=4,
-        cycle1_enabled=1, cycle1_start="14:00:00", cycle1_stop="18:00:00",
-        speed_cycle1=2, pool_volume=50,
+        cycle1_enabled=1,
+        cycle1_start="14:00:00",
+        cycle1_stop="18:00:00",
+        speed_cycle1=2,
+        pool_volume=50,
     )
     coordinator.data = PoolCopData(status=status)
 
@@ -373,7 +401,9 @@ async def test_cycle_with_zero_times(coordinator):
     """Cycle enabled but times 00:00:00 -> 0 remaining."""
     status = _make_status(
         op_mode=4,
-        cycle1_enabled=1, cycle1_start="00:00:00", cycle1_stop="00:00:00",
+        cycle1_enabled=1,
+        cycle1_start="00:00:00",
+        cycle1_stop="00:00:00",
     )
     coordinator.data = PoolCopData(status=status)
     assert coordinator.planned_remaining_volume == 0.0
@@ -383,7 +413,9 @@ async def test_cycle_stop_before_start(coordinator):
     """Cycle where stop < start (overnight) -> 0 remaining."""
     status = _make_status(
         op_mode=4,
-        cycle1_enabled=1, cycle1_start="22:00:00", cycle1_stop="06:00:00",
+        cycle1_enabled=1,
+        cycle1_start="22:00:00",
+        cycle1_stop="06:00:00",
     )
     coordinator.data = PoolCopData(status=status)
 
@@ -402,7 +434,9 @@ async def test_cycle_invalid_time_string(coordinator):
     """Cycle with unparsable time string -> 0 remaining."""
     status = _make_status(
         op_mode=4,
-        cycle1_enabled=1, cycle1_start="bad", cycle1_stop="also_bad",
+        cycle1_enabled=1,
+        cycle1_start="bad",
+        cycle1_stop="also_bad",
     )
     coordinator.data = PoolCopData(status=status)
     assert coordinator.planned_remaining_volume == 0.0
@@ -418,9 +452,11 @@ async def test_flow_rate_fallback_to_pumpspeed(coordinator):
     """When speed_cycle has no matching flow rate, fall back to pumpspeed."""
     status = _make_status(
         op_mode=4,
-        cycle1_enabled=1, cycle1_start="14:00:00", cycle1_stop="18:00:00",
+        cycle1_enabled=1,
+        cycle1_start="14:00:00",
+        cycle1_stop="18:00:00",
         speed_cycle1=99,  # No flow rate configured for speed 99
-        pump_speed=2,     # Fallback to pumpspeed=2 -> 15 m³/h
+        pump_speed=2,  # Fallback to pumpspeed=2 -> 15 m³/h
     )
     coordinator.data = PoolCopData(status=status)
 
@@ -440,9 +476,11 @@ async def test_flow_rate_fallback_unknown_speeds(coordinator):
     """When both speed_cycle and pumpspeed are unconfigured -> 0."""
     status = _make_status(
         op_mode=4,
-        cycle1_enabled=1, cycle1_start="14:00:00", cycle1_stop="18:00:00",
+        cycle1_enabled=1,
+        cycle1_start="14:00:00",
+        cycle1_stop="18:00:00",
         speed_cycle1=99,  # Unknown - no flow rate for 99
-        pump_speed=99,    # Also unknown
+        pump_speed=99,  # Also unknown
     )
     coordinator.data = PoolCopData(status=status)
 
@@ -462,7 +500,9 @@ async def test_flow_rate_fallback_to_speed1(coordinator):
     """When pumpspeed is missing from status, fall back to speed 1."""
     status = _make_status(
         op_mode=4,
-        cycle1_enabled=1, cycle1_start="14:00:00", cycle1_stop="18:00:00",
+        cycle1_enabled=1,
+        cycle1_start="14:00:00",
+        cycle1_stop="18:00:00",
         speed_cycle1=99,  # Unknown
     )
     del status["PoolCop"]["status"]["pumpspeed"]  # No pumpspeed at all
@@ -496,7 +536,9 @@ async def test_cycle_speed_invalid(coordinator):
     """Timer mode with non-integer speed_cycle -> fallback works."""
     status = _make_status(
         op_mode=4,
-        cycle1_enabled=1, cycle1_start="14:00:00", cycle1_stop="18:00:00",
+        cycle1_enabled=1,
+        cycle1_start="14:00:00",
+        cycle1_stop="18:00:00",
     )
     status["PoolCop"]["settings"]["pump"]["speed_cycle1"] = "bad"
     coordinator.data = PoolCopData(status=status)
@@ -517,7 +559,9 @@ async def test_cycle_no_speed_setting(coordinator):
     """Timer mode with missing speed_cycle key -> fallback to pumpspeed."""
     status = _make_status(
         op_mode=4,
-        cycle1_enabled=1, cycle1_start="14:00:00", cycle1_stop="18:00:00",
+        cycle1_enabled=1,
+        cycle1_start="14:00:00",
+        cycle1_stop="18:00:00",
     )
     del status["PoolCop"]["settings"]["pump"]["speed_cycle1"]
     coordinator.data = PoolCopData(status=status)
@@ -590,7 +634,9 @@ async def test_cycle_bad_timezone_fallback(coordinator):
     """Cycle timer with invalid timezone -> falls back, still works."""
     status = _make_status(
         op_mode=4,
-        cycle1_enabled=1, cycle1_start="14:00:00", cycle1_stop="18:00:00",
+        cycle1_enabled=1,
+        cycle1_start="14:00:00",
+        cycle1_stop="18:00:00",
     )
     status["Pool"]["timezone"] = "Bogus/TZ"
     coordinator.data = PoolCopData(status=status)

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -74,8 +74,16 @@ def test_is_component_installed_autochlor():
     data_off = _make_data({"autochlor": 0})
     data_on = _make_data({"autochlor": 1})
 
-    assert PoolCopEntity.is_component_installed(FakeCoordinator(data_off), "autochlor_control") is False
-    assert PoolCopEntity.is_component_installed(FakeCoordinator(data_on), "autochlor_auto") is True
+    assert (
+        PoolCopEntity.is_component_installed(
+            FakeCoordinator(data_off), "autochlor_control"
+        )
+        is False
+    )
+    assert (
+        PoolCopEntity.is_component_installed(FakeCoordinator(data_on), "autochlor_auto")
+        is True
+    )
 
 
 def test_is_component_installed_waterlevel():
@@ -83,8 +91,16 @@ def test_is_component_installed_waterlevel():
     data_on = _make_data({"waterlevel": 1})
     data_off = _make_data({"waterlevel": 0})
 
-    assert PoolCopEntity.is_component_installed(FakeCoordinator(data_on), "waterlevel_auto_add") is True
-    assert PoolCopEntity.is_component_installed(FakeCoordinator(data_off), "water_level") is False
+    assert (
+        PoolCopEntity.is_component_installed(
+            FakeCoordinator(data_on), "waterlevel_auto_add"
+        )
+        is True
+    )
+    assert (
+        PoolCopEntity.is_component_installed(FakeCoordinator(data_off), "water_level")
+        is False
+    )
 
 
 def test_is_component_installed_air():
@@ -92,8 +108,18 @@ def test_is_component_installed_air():
     data_on = _make_data({"air": 1})
     data_off = _make_data({"air": 0})
 
-    assert PoolCopEntity.is_component_installed(FakeCoordinator(data_on), "temperature_air") is True
-    assert PoolCopEntity.is_component_installed(FakeCoordinator(data_off), "temperature_air") is False
+    assert (
+        PoolCopEntity.is_component_installed(
+            FakeCoordinator(data_on), "temperature_air"
+        )
+        is True
+    )
+    assert (
+        PoolCopEntity.is_component_installed(
+            FakeCoordinator(data_off), "temperature_air"
+        )
+        is False
+    )
 
 
 def test_is_component_installed_always_true():

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -265,9 +265,6 @@ async def test_time_str_to_time_today_tomorrow_shift():
     """_time_str_to_time_today shifts to tomorrow when result < now and hour < 12 (line 171)."""
     from unittest.mock import patch as mock_patch
 
-    import zoneinfo
-
-    utc = zoneinfo.ZoneInfo("UTC")
     real_datetime = datetime
 
     class FakeDatetime(datetime):
@@ -333,9 +330,7 @@ async def test_timer_time_fn_exception():
 async def test_weekday_mapping_fn_non_integer_value():
     """_weekday_mapping_fn returns None for non-integer value (lines 264-265)."""
     fn = _weekday_mapping_fn("settings.orp.hyper_day")
-    data = PoolCopData(
-        status={"PoolCop": {"settings": {"orp": {"hyper_day": "bad"}}}}
-    )
+    data = PoolCopData(status={"PoolCop": {"settings": {"orp": {"hyper_day": "bad"}}}})
     assert fn(data) is None
 
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -201,9 +201,7 @@ async def test_service_toggle_pump_error(
 
     mock_poolcop.toggle_pump.side_effect = ConnectionError("offline")
 
-    await hass.services.async_call(
-        DOMAIN, SERVICE_TOGGLE_PUMP, {}, blocking=True
-    )
+    await hass.services.async_call(DOMAIN, SERVICE_TOGGLE_PUMP, {}, blocking=True)
 
 
 async def test_service_toggle_aux_error(
@@ -264,6 +262,4 @@ async def test_service_clear_alarm_error(
 
     mock_poolcop.clear_alarm.side_effect = ConnectionError("offline")
 
-    await hass.services.async_call(
-        DOMAIN, SERVICE_CLEAR_ALARM, {}, blocking=True
-    )
+    await hass.services.async_call(DOMAIN, SERVICE_CLEAR_ALARM, {}, blocking=True)


### PR DESCRIPTION
## Summary
- Save `daily_volume` and `daily_volume_date` to persistent storage alongside existing cycle_durations and flow_rates
- On load, only restore if stored date matches today — stale data from a previous day is discarded
- Fixes daily filtration volume dropping to 0 after HA restart

## Test plan
- [x] `test_save_load_learned_data` — verifies daily_volume fields included in save and restored on load
- [x] `test_load_stale_daily_volume_discarded` — verifies yesterday's volume is not restored
- [x] All 210 tests pass, 100% coverage maintained

🤖 Generated with [Claude Code](https://claude.com/claude-code)