### PR TITLE
Fix cycle predicted end timezone and switch state refresh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.6.9
+  rev: v0.15.5
   hooks:
     - id: ruff
       args: ["--fix"]

--- a/custom_components/poolcop/manifest.json
+++ b/custom_components/poolcop/manifest.json
@@ -7,5 +7,5 @@
   "issue_tracker": "https://github.com/sstriker/hass-poolcop/issues",
   "iot_class": "cloud_polling",
   "requirements": ["poolcop==0.7.0"],
-  "version": "2.0.3"
+  "version": "2.0.4"
 }

--- a/custom_components/poolcop/sensor.py
+++ b/custom_components/poolcop/sensor.py
@@ -141,7 +141,13 @@ def _cycle_end_time_fn(data: PoolCopData) -> datetime | None:
         return None
     if data.cycle_status and data.cycle_status.get("predicted_end") is not None:
         timestamp = data.cycle_status["predicted_end"]
-        return datetime.fromtimestamp(timestamp)
+        # Use the pool's timezone so the predicted end time is correct locally
+        pool_tz = data.status_value("timezone", prefix="Pool") or "UTC"
+        try:
+            tz_info = zoneinfo.ZoneInfo(pool_tz)
+        except ValueError, zoneinfo.ZoneInfoNotFoundError:
+            tz_info = zoneinfo.ZoneInfo("UTC")
+        return datetime.fromtimestamp(timestamp, tz=tz_info)
     return None
 
 

--- a/custom_components/poolcop/switch.py
+++ b/custom_components/poolcop/switch.py
@@ -55,12 +55,12 @@ class PoolCopPumpSwitch(PoolCopEntity, SwitchEntity):  # type: ignore[misc]
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the pump on."""
         await self.coordinator.toggle_pump(turn_on=True)
-        self.async_write_ha_state()
+        await self.coordinator.async_request_refresh()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the pump off."""
         await self.coordinator.toggle_pump(turn_on=False)
-        self.async_write_ha_state()
+        await self.coordinator.async_request_refresh()
 
 
 class PoolCopAuxSwitch(PoolCopEntity, SwitchEntity):  # type: ignore[misc]
@@ -129,10 +129,10 @@ class PoolCopAuxSwitch(PoolCopEntity, SwitchEntity):  # type: ignore[misc]
         """Turn the aux output on."""
         if not self.is_on:
             await self.coordinator.toggle_auxiliary(self._aux_id)
-            self.async_write_ha_state()
+            await self.coordinator.async_request_refresh()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the aux output off."""
         if self.is_on:
             await self.coordinator.toggle_auxiliary(self._aux_id)
-            self.async_write_ha_state()
+            await self.coordinator.async_request_refresh()


### PR DESCRIPTION
## Summary
- **cycle_predicted_end sensor** used a naive datetime (no timezone), causing `ValueError: missing timezone information` on every poll cycle. Now uses the pool's configured timezone.
- **Pump and aux switches** called `async_write_ha_state()` after toggle, which published stale coordinator data. Now calls `async_request_refresh()` so the state actually reflects the API response.

## Test plan
- [ ] Verify `cycle_predicted_end` no longer throws ValueError in logs
- [ ] Verify pump switch toggles and reflects correct state
- [ ] Verify aux switches toggle and reflect correct state

🤖 Generated with [Claude Code](https://claude.com/claude-code)