### PR TITLE
fix: stable entity IDs using poolcop_id

### DIFF
--- a/custom_components/poolcop/device_tracker.py
+++ b/custom_components/poolcop/device_tracker.py
@@ -34,7 +34,8 @@ async def async_setup_entry(
     except ValueError, TypeError:
         return
 
-    async_add_entities([PoolCopTracker(coordinator, pool_data)])
+    nickname = pool_data.get("nickname")
+    async_add_entities([PoolCopTracker(coordinator, pool_data, nickname)])
 
 
 class PoolCopTracker(PoolCopEntity, TrackerEntity):  # type: ignore[misc]
@@ -46,18 +47,26 @@ class PoolCopTracker(PoolCopEntity, TrackerEntity):  # type: ignore[misc]
         self,
         coordinator: PoolCopDataUpdateCoordinator,
         pool_data: dict,
+        nickname: str | None = None,
     ) -> None:
         """Initialize the pool tracker."""
         super().__init__(
             coordinator=coordinator,
             description=EntityDescription(key="pool_location", name="Pool"),
         )
+        if nickname:
+            self._attr_name = nickname
         self._latitude = float(pool_data["latitude"])
         self._longitude = float(pool_data["longitude"])
 
         image = pool_data.get("image")
         if image:
             self._attr_entity_picture = image
+
+    @property
+    def suggested_object_id(self) -> str:
+        """Return a stable object id independent of the display name."""
+        return "pool"
 
     @property
     def latitude(self) -> float:

--- a/custom_components/poolcop/entity.py
+++ b/custom_components/poolcop/entity.py
@@ -65,10 +65,7 @@ class PoolCopEntity(CoordinatorEntity[PoolCopDataUpdateCoordinator]):
         """Return device information about this PoolCop instance."""
         poolcop_id: str = cast(str, self.coordinator.config_entry.unique_id)
 
-        # Use Pool nickname if available, fall back to "PoolCop"
-        pool_data = self.coordinator.data.status_value("", prefix="Pool") or {}
-        nickname = pool_data.get("nickname") if isinstance(pool_data, dict) else None
-        name = nickname or "PoolCop"
+        name = f"PoolCop {poolcop_id}"
 
         info = DeviceInfo(
             entry_type=DeviceEntryType.SERVICE,

--- a/custom_components/poolcop/manifest.json
+++ b/custom_components/poolcop/manifest.json
@@ -7,5 +7,5 @@
   "issue_tracker": "https://github.com/sstriker/hass-poolcop/issues",
   "iot_class": "cloud_polling",
   "requirements": ["poolcop==0.7.0"],
-  "version": "2.0.4"
+  "version": "2.0.5"
 }

--- a/custom_components/poolcop/sensor.py
+++ b/custom_components/poolcop/sensor.py
@@ -459,6 +459,13 @@ SENSORS: tuple[PoolCopSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.TIMESTAMP,
         value_fn=_cycle_end_time_fn,
     ),
+    PoolCopSensorEntityDescription(
+        key="pool_nickname",
+        name="Pool Nickname",
+        icon="mdi:tag-text",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: data.status_value("nickname", prefix="Pool"),
+    ),
 )
 
 # Additional sensors for pool settings

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -43,7 +43,7 @@ async def test_pump_sensor_on(
     """pump=1 → is_on True."""
     await _setup_integration(hass, mock_config_entry, mock_poolcop, mock_poolcop_data)
 
-    state = hass.states.get("binary_sensor.test_pool_pump")
+    state = hass.states.get("binary_sensor.poolcop_test_poolcop_id_pump")
     assert state is not None
     assert state.state == "on"
 
@@ -62,7 +62,7 @@ async def test_active_alarm_on(
     ]
     await _setup_integration(hass, mock_config_entry, mock_poolcop, mock_poolcop_data)
 
-    state = hass.states.get("binary_sensor.test_pool_active_alarm")
+    state = hass.states.get("binary_sensor.poolcop_test_poolcop_id_active_alarm")
     assert state is not None
     assert state.state == "on"
     assert state.attributes.get("alarm_count", 0) >= 1
@@ -74,7 +74,7 @@ async def test_active_alarm_off(
     """No alarms → is_on False."""
     await _setup_integration(hass, mock_config_entry, mock_poolcop, mock_poolcop_data)
 
-    state = hass.states.get("binary_sensor.test_pool_active_alarm")
+    state = hass.states.get("binary_sensor.poolcop_test_poolcop_id_active_alarm")
     assert state is not None
     assert state.state == "off"
 
@@ -126,7 +126,7 @@ async def test_icon_selection(
     """pump on → mdi:pump, off → mdi:pump-off."""
     await _setup_integration(hass, mock_config_entry, mock_poolcop, mock_poolcop_data)
 
-    state = hass.states.get("binary_sensor.test_pool_pump")
+    state = hass.states.get("binary_sensor.poolcop_test_poolcop_id_pump")
     assert state is not None
     # Pump is on (status.pump=1)
     assert state.attributes.get("icon") == "mdi:pump"
@@ -180,7 +180,7 @@ async def test_aux_binary_sensor_icon_with_label(
     await _setup_integration(hass, mock_config_entry, mock_poolcop, mock_poolcop_data)
 
     # Entity name is derived from label: "Pool Light" → "pool_light"
-    state = hass.states.get("binary_sensor.test_pool_pool_light")
+    state = hass.states.get("binary_sensor.poolcop_test_poolcop_id_pool_light")
     assert state is not None
     # label_id=0 (Pool Light), status=1 → icons[0] = "mdi:lightbulb-on"
     assert state.attributes.get("icon") == "mdi:lightbulb-on"

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -28,7 +28,7 @@ async def test_clear_alarm_button_setup(
     """Button entity exists."""
     await _setup_integration(hass, mock_config_entry, mock_poolcop, mock_poolcop_data)
 
-    state = hass.states.get("button.test_pool_clear_alarm")
+    state = hass.states.get("button.poolcop_test_poolcop_id_clear_alarm")
     assert state is not None
 
 
@@ -41,7 +41,7 @@ async def test_clear_alarm_button_press(
     await hass.services.async_call(
         "button",
         "press",
-        {"entity_id": "button.test_pool_clear_alarm"},
+        {"entity_id": "button.poolcop_test_poolcop_id_clear_alarm"},
         blocking=True,
     )
     mock_poolcop.clear_alarm.assert_called()

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -28,7 +28,7 @@ async def test_tracker_with_coords(
     """lat/lon → tracker entity."""
     await _setup_integration(hass, mock_config_entry, mock_poolcop, mock_poolcop_data)
 
-    state = hass.states.get("device_tracker.test_pool_pool")
+    state = hass.states.get("device_tracker.poolcop_test_poolcop_id_pool")
     assert state is not None
     assert state.attributes.get("latitude") == 48.86
     assert state.attributes.get("longitude") == 2.35
@@ -41,7 +41,7 @@ async def test_tracker_no_coords(
     del mock_poolcop_data["Pool"]
     await _setup_integration(hass, mock_config_entry, mock_poolcop, mock_poolcop_data)
 
-    state = hass.states.get("device_tracker.test_pool_pool")
+    state = hass.states.get("device_tracker.poolcop_test_poolcop_id_pool")
     assert state is None
 
 
@@ -51,7 +51,7 @@ async def test_tracker_properties(
     """source_type, icon, extra attrs."""
     await _setup_integration(hass, mock_config_entry, mock_poolcop, mock_poolcop_data)
 
-    state = hass.states.get("device_tracker.test_pool_pool")
+    state = hass.states.get("device_tracker.poolcop_test_poolcop_id_pool")
     assert state is not None
     assert state.attributes.get("source_type") == "gps"
     assert state.attributes.get("icon") == "mdi:pool"
@@ -66,7 +66,7 @@ async def test_tracker_non_dict_pool_data(
     mock_poolcop_data["Pool"] = "not a dict"
     await _setup_integration(hass, mock_config_entry, mock_poolcop, mock_poolcop_data)
 
-    assert hass.states.get("device_tracker.test_pool_pool") is None
+    assert hass.states.get("device_tracker.poolcop_test_poolcop_id_pool") is None
 
 
 async def test_tracker_invalid_coords(
@@ -76,7 +76,7 @@ async def test_tracker_invalid_coords(
     mock_poolcop_data["Pool"]["latitude"] = "not-a-number"
     await _setup_integration(hass, mock_config_entry, mock_poolcop, mock_poolcop_data)
 
-    assert hass.states.get("device_tracker.test_pool_pool") is None
+    assert hass.states.get("device_tracker.poolcop_test_poolcop_id_pool") is None
 
 
 async def test_tracker_with_image(
@@ -86,7 +86,7 @@ async def test_tracker_with_image(
     mock_poolcop_data["Pool"]["image"] = "https://example.com/pool.jpg"
     await _setup_integration(hass, mock_config_entry, mock_poolcop, mock_poolcop_data)
 
-    state = hass.states.get("device_tracker.test_pool_pool")
+    state = hass.states.get("device_tracker.poolcop_test_poolcop_id_pool")
     assert state is not None
     assert state.attributes.get("entity_picture") == "https://example.com/pool.jpg"
 
@@ -99,7 +99,7 @@ async def test_tracker_extra_state_attributes_non_dict(
         hass, mock_config_entry, mock_poolcop, mock_poolcop_data
     )
 
-    state = hass.states.get("device_tracker.test_pool_pool")
+    state = hass.states.get("device_tracker.poolcop_test_poolcop_id_pool")
     assert state is not None
 
     # Now change Pool data to non-dict and trigger an update
@@ -111,7 +111,7 @@ async def test_tracker_extra_state_attributes_non_dict(
     coordinator.async_set_updated_data(coordinator.data)
     await hass.async_block_till_done()
 
-    state = hass.states.get("device_tracker.test_pool_pool")
+    state = hass.states.get("device_tracker.poolcop_test_poolcop_id_pool")
     assert state is not None
     # timezone and nickname should not be present when pool data is non-dict
     assert "timezone" not in state.attributes

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -28,7 +28,7 @@ async def test_valve_position_setup(
     """Entity exists with correct options."""
     await _setup_integration(hass, mock_config_entry, mock_poolcop, mock_poolcop_data)
 
-    state = hass.states.get("select.test_pool_valve_position")
+    state = hass.states.get("select.poolcop_test_poolcop_id_valve_position")
     assert state is not None
     assert "Filter" in state.attributes.get("options", [])
     assert "Backwash" in state.attributes.get("options", [])
@@ -41,7 +41,7 @@ async def test_valve_position_current(
     # mock_poolcop_data has valveposition=1
     await _setup_integration(hass, mock_config_entry, mock_poolcop, mock_poolcop_data)
 
-    state = hass.states.get("select.test_pool_valve_position")
+    state = hass.states.get("select.poolcop_test_poolcop_id_valve_position")
     assert state is not None
     assert state.state == "Waste"
 
@@ -55,7 +55,7 @@ async def test_valve_position_set(
     await hass.services.async_call(
         "select",
         "select_option",
-        {"entity_id": "select.test_pool_valve_position", "option": "Backwash"},
+        {"entity_id": "select.poolcop_test_poolcop_id_valve_position", "option": "Backwash"},
         blocking=True,
     )
     mock_poolcop.set_valve_position.assert_called_once_with(3)
@@ -67,7 +67,7 @@ async def test_pump_speed_options_3_speed(
     """nb_speed=3 → ['0','1','2','3']."""
     await _setup_integration(hass, mock_config_entry, mock_poolcop, mock_poolcop_data)
 
-    state = hass.states.get("select.test_pool_pump_speed")
+    state = hass.states.get("select.poolcop_test_poolcop_id_pump_speed")
     assert state is not None
     assert state.attributes.get("options") == ["0", "1", "2", "3"]
 
@@ -78,7 +78,7 @@ async def test_pump_speed_current(
     """speed=2 → '2'."""
     await _setup_integration(hass, mock_config_entry, mock_poolcop, mock_poolcop_data)
 
-    state = hass.states.get("select.test_pool_pump_speed")
+    state = hass.states.get("select.poolcop_test_poolcop_id_pump_speed")
     assert state is not None
     assert state.state == "2"
 
@@ -92,7 +92,7 @@ async def test_pump_speed_set(
     await hass.services.async_call(
         "select",
         "select_option",
-        {"entity_id": "select.test_pool_pump_speed", "option": "3"},
+        {"entity_id": "select.poolcop_test_poolcop_id_pump_speed", "option": "3"},
         blocking=True,
     )
     mock_poolcop.set_pump_speed.assert_called_once_with(3)
@@ -119,7 +119,7 @@ async def test_pump_speed_non_int_pumpspeed(
     mock_poolcop_data["PoolCop"]["status"]["pumpspeed"] = "bad"
     await _setup_integration(hass, mock_config_entry, mock_poolcop, mock_poolcop_data)
 
-    state = hass.states.get("select.test_pool_pump_speed")
+    state = hass.states.get("select.poolcop_test_poolcop_id_pump_speed")
     assert state is not None
     assert state.state == "unknown"
 
@@ -132,7 +132,7 @@ async def test_pump_speed_fallback_pump_type_3(
     mock_poolcop_data["PoolCop"]["conf"]["pump_type"] = 3
     await _setup_integration(hass, mock_config_entry, mock_poolcop, mock_poolcop_data)
 
-    state = hass.states.get("select.test_pool_pump_speed")
+    state = hass.states.get("select.poolcop_test_poolcop_id_pump_speed")
     assert state is not None
     assert state.attributes.get("options") == ["0", "1", "2", "3"]
 
@@ -145,7 +145,7 @@ async def test_pump_speed_fallback_pump_type_2(
     mock_poolcop_data["PoolCop"]["conf"]["pump_type"] = 2
     await _setup_integration(hass, mock_config_entry, mock_poolcop, mock_poolcop_data)
 
-    state = hass.states.get("select.test_pool_pump_speed")
+    state = hass.states.get("select.poolcop_test_poolcop_id_pump_speed")
     assert state is not None
     assert state.attributes.get("options") == ["0", "1", "2"]
 
@@ -158,7 +158,7 @@ async def test_pump_speed_fallback_pump_type_1(
     mock_poolcop_data["PoolCop"]["conf"]["pump_type"] = 1
     await _setup_integration(hass, mock_config_entry, mock_poolcop, mock_poolcop_data)
 
-    state = hass.states.get("select.test_pool_pump_speed")
+    state = hass.states.get("select.poolcop_test_poolcop_id_pump_speed")
     assert state is not None
     assert state.attributes.get("options") == ["0", "1"]
 
@@ -170,6 +170,6 @@ async def test_valve_position_unknown_value(
     mock_poolcop_data["PoolCop"]["status"]["valveposition"] = 99
     await _setup_integration(hass, mock_config_entry, mock_poolcop, mock_poolcop_data)
 
-    state = hass.states.get("select.test_pool_valve_position")
+    state = hass.states.get("select.poolcop_test_poolcop_id_valve_position")
     assert state is not None
     assert state.state == "unknown"

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -50,7 +50,7 @@ async def test_water_temperature_value(
     """State == '26.5'."""
     await _setup_integration(hass, mock_config_entry, mock_poolcop, mock_poolcop_data)
 
-    state = hass.states.get("sensor.test_pool_water_temperature")
+    state = hass.states.get("sensor.poolcop_test_poolcop_id_water_temperature")
     assert state is not None
     assert state.state == "26.5"
 
@@ -68,7 +68,7 @@ async def test_sensor_extra_attrs(
     """valve_position sensor has description attr."""
     await _setup_integration(hass, mock_config_entry, mock_poolcop, mock_poolcop_data)
 
-    state = hass.states.get("sensor.test_pool_valve_position")
+    state = hass.states.get("sensor.poolcop_test_poolcop_id_valve_position")
     if state is not None:
         assert "description" in state.attributes
 
@@ -171,7 +171,7 @@ async def test_planned_remaining_volume_value(
         hass, mock_config_entry, mock_poolcop, mock_poolcop_data
     )
 
-    state = hass.states.get("sensor.test_pool_planned_remaining_filter_volume")
+    state = hass.states.get("sensor.poolcop_test_poolcop_id_planned_remaining_filter_volume")
     assert state is not None
     # Value should match what coordinator returns (numeric string)
     expected = str(coordinator.planned_remaining_volume)

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -28,7 +28,7 @@ async def test_pump_switch_state_on(
     """status.pump=1 → state 'on'."""
     await _setup_integration(hass, mock_config_entry, mock_poolcop, mock_poolcop_data)
 
-    state = hass.states.get("switch.test_pool_pump")
+    state = hass.states.get("switch.poolcop_test_poolcop_id_pump")
     assert state is not None
     assert state.state == "on"
 
@@ -40,7 +40,7 @@ async def test_pump_switch_turn_off(
     await _setup_integration(hass, mock_config_entry, mock_poolcop, mock_poolcop_data)
 
     await hass.services.async_call(
-        "switch", "turn_off", {"entity_id": "switch.test_pool_pump"}, blocking=True
+        "switch", "turn_off", {"entity_id": "switch.poolcop_test_poolcop_id_pump"}, blocking=True
     )
     mock_poolcop.toggle_pump.assert_called_once()
 
@@ -52,7 +52,7 @@ async def test_pump_switch_turn_on(
     await _setup_integration(hass, mock_config_entry, mock_poolcop, mock_poolcop_data)
 
     await hass.services.async_call(
-        "switch", "turn_on", {"entity_id": "switch.test_pool_pump"}, blocking=True
+        "switch", "turn_on", {"entity_id": "switch.poolcop_test_poolcop_id_pump"}, blocking=True
     )
     # Pump is already on (status.pump==1), so toggle_pump should NOT be called
     mock_poolcop.toggle_pump.assert_not_called()
@@ -68,7 +68,7 @@ async def test_aux_switch_is_on(
             aux["status"] = 1
     await _setup_integration(hass, mock_config_entry, mock_poolcop, mock_poolcop_data)
 
-    state = hass.states.get("switch.test_pool_transfer_pump")
+    state = hass.states.get("switch.poolcop_test_poolcop_id_transfer_pump")
     assert state is not None
     assert state.state == "on"
 
@@ -85,7 +85,7 @@ async def test_aux_switch_turn_on_when_off(
     await hass.services.async_call(
         "switch",
         "turn_on",
-        {"entity_id": "switch.test_pool_transfer_pump"},
+        {"entity_id": "switch.poolcop_test_poolcop_id_transfer_pump"},
         blocking=True,
     )
     mock_poolcop.toggle_auxiliary.assert_called_once_with(4)
@@ -103,7 +103,7 @@ async def test_aux_switch_idempotent(
     await hass.services.async_call(
         "switch",
         "turn_on",
-        {"entity_id": "switch.test_pool_transfer_pump"},
+        {"entity_id": "switch.poolcop_test_poolcop_id_transfer_pump"},
         blocking=True,
     )
     mock_poolcop.toggle_auxiliary.assert_not_called()
@@ -132,7 +132,7 @@ async def test_aux_switch_is_on_returns_none_when_not_found(
     coordinator.async_set_updated_data(coordinator.data)
     await hass.async_block_till_done()
 
-    state = hass.states.get("switch.test_pool_transfer_pump")
+    state = hass.states.get("switch.poolcop_test_poolcop_id_transfer_pump")
     assert state is not None
     # When is_on returns None, HA shows state as unknown
     assert state.state == "unknown"
@@ -161,7 +161,7 @@ async def test_aux_switch_extra_state_attributes_not_found(
     coordinator.async_set_updated_data(coordinator.data)
     await hass.async_block_till_done()
 
-    state = hass.states.get("switch.test_pool_transfer_pump")
+    state = hass.states.get("switch.poolcop_test_poolcop_id_transfer_pump")
     assert state is not None
     # No label, slave, or days attributes when aux not found
     assert "label" not in state.attributes
@@ -180,7 +180,7 @@ async def test_aux_switch_icon_no_label_match(
             aux["switchable"] = True
     await _setup_integration(hass, mock_config_entry, mock_poolcop, mock_poolcop_data)
 
-    state = hass.states.get("switch.test_pool_available")
+    state = hass.states.get("switch.poolcop_test_poolcop_id_available")
     assert state is not None
     # label_id 15 is not in AUX_LABEL_ICONS, so icon should not be set
     assert "icon" not in state.attributes
@@ -198,7 +198,7 @@ async def test_aux_switch_turn_off_when_on(
     await hass.services.async_call(
         "switch",
         "turn_off",
-        {"entity_id": "switch.test_pool_transfer_pump"},
+        {"entity_id": "switch.poolcop_test_poolcop_id_transfer_pump"},
         blocking=True,
     )
     mock_poolcop.toggle_auxiliary.assert_called_once_with(4)
@@ -216,7 +216,7 @@ async def test_aux_switch_turn_off_when_already_off(
     await hass.services.async_call(
         "switch",
         "turn_off",
-        {"entity_id": "switch.test_pool_transfer_pump"},
+        {"entity_id": "switch.poolcop_test_poolcop_id_transfer_pump"},
         blocking=True,
     )
     mock_poolcop.toggle_auxiliary.assert_not_called()


### PR DESCRIPTION
## Summary
- Device name changed from Pool nickname to `PoolCop {poolcop_id}` for stable entity IDs (e.g. `sensor.poolcop_2478_water_temperature`)
- Added `pool_nickname` diagnostic sensor to expose the nickname as a proper entity
- Device tracker uses `suggested_object_id` for stable `device_tracker.poolcop_{id}_pool` entity ID while showing the nickname as friendly name on the map via `_attr_name`
- Bump version to 2.0.5

## Test plan
- [x] All 198 tests pass (99% coverage)
- [ ] Verify entity IDs use `poolcop_{id}_*` pattern on real HA instance
- [ ] Confirm device tracker shows nickname on map hover
- [ ] Confirm `sensor.poolcop_{id}_pool_nickname` shows the pool name

🤖 Generated with [Claude Code](https://claude.com/claude-code)