### PR TITLE
Bump version from 2.0.5 to 2.1.0

### DIFF
--- a/custom_components/poolcop/manifest.json
+++ b/custom_components/poolcop/manifest.json
@@ -7,5 +7,5 @@
   "issue_tracker": "https://github.com/sstriker/hass-poolcop/issues",
   "iot_class": "cloud_polling",
   "requirements": ["poolcop==0.7.0"],
-  "version": "2.0.5"
+  "version": "2.1.0"
 }


### PR DESCRIPTION
## Summary
- Minor version bump reflecting new features since 2.0.5:
  - geo_location entity replacing device_tracker (PR #10)
  - Official PoolCop branding (PR #11)
  - Stable entity IDs using poolcop_id

🤖 Generated with [Claude Code](https://claude.com/claude-code)